### PR TITLE
Update caniuse for correct browser detection in unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,12 +35,6 @@
             "node-releases": "^1.1.58"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001099",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
-          "integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.3.496",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.496.tgz",
@@ -217,12 +211,6 @@
             "escalade": "^3.0.1",
             "node-releases": "^1.1.58"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001099",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
-          "integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA==",
-          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.496",
@@ -5185,12 +5173,6 @@
             "node-releases": "^1.1.58"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001099",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
-          "integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA==",
-          "dev": true
-        },
         "chokidar": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
@@ -6406,12 +6388,6 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001099",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
-          "integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA==",
           "dev": true
         },
         "chokidar": {
@@ -11118,9 +11094,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000989",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-      "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+      "version": "1.0.30001103",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001103.tgz",
+      "integrity": "sha512-EJkTPrZrgy712tjZ7GQDye5A67SQOyNS6X9b6GS/e5QFu5Renv5qfkx3GHq1S+vObxKzbWWYuPO/7nt4kYW/gA==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -14077,12 +14053,6 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001099",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
-          "integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA==",
           "dev": true
         },
         "chokidar": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:integration": "tsc && npm run build:webpack && mocha test/integration --timeout=15000",
     "test:sauce": "tsc && polymer test --module-resolution=node --npm -s 'windows 10/microsoftedge@17' -s 'macos 10.13/safari@11'",
     "test:regenerate_screenshots": "tsc && mocha test/integration/screenshots-baseline/regenerate.js --timeout=25000",
-    "test:karma": "tsc && karma start --coverage --compatibility none",
+    "test:karma": "tsc && karma start --coverage",
     "test:karma_single": "tsc && karma start --coverage --grep test/reducers/live.test.js",
     "test:watch": "karma start --auto-watch=true --single-run=false",
     "test:update-snapshots": "karma start --update-snapshots",


### PR DESCRIPTION
Running karma unit tests would display this warning: `Browserslist: caniuse-lite is outdated. Please run next command `npm update`.

Also, it wasn't able to detect Chrome 83 as a modern browser, requiring the karma ` --compatibility none` flag to prevent it from compiling to es5 (i.e. defaulting to "max" compatibility).

Searching found a suggestion to manually update via `npx browserslist@latest --update-db`.