### PR TITLE
Use page objects for all screenshot tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
         "deepmerge": "^4.2.2",
         "eslint": "^7.32.0",
         "eslint-config-google": "^0.14.0",
-        "esm": "^3.2.25",
         "fake-indexeddb": "^3.0.0",
         "firebase-tools": "^9.1.0",
         "html-webpack-plugin": "^3.2.0",
@@ -15153,15 +15152,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/espree": {
@@ -46224,12 +46214,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
       "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
-      "dev": true
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true
     },
     "espree": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "deepmerge": "^4.2.2",
     "eslint": "^7.32.0",
     "eslint-config-google": "^0.14.0",
-    "esm": "^3.2.25",
     "fake-indexeddb": "^3.0.0",
     "firebase-tools": "^9.1.0",
     "html-webpack-plugin": "^3.2.0",

--- a/test/integration/pages/error-page.ts
+++ b/test/integration/pages/error-page.ts
@@ -1,0 +1,10 @@
+import { PageObject, PageOptions } from './page-object.js';
+
+export class ErrorPage extends PageObject {
+
+  constructor(options: PageOptions = {}) {
+    super({
+      ...options,
+    });
+  }
+}

--- a/test/integration/pages/game-detail-page.ts
+++ b/test/integration/pages/game-detail-page.ts
@@ -1,0 +1,13 @@
+import { PageObject, PageOptions } from './page-object.js';
+
+export class GameDetailPage extends PageObject {
+
+  constructor(options: PageOptions = {}) {
+    super({
+      ...options,
+      scenarioName: 'viewGameDetail',
+      route: 'game/test_game1?team=test_team1'
+    });
+  }
+
+}

--- a/test/integration/pages/game-list-page.ts
+++ b/test/integration/pages/game-list-page.ts
@@ -1,0 +1,13 @@
+import { PageObject, PageOptions } from './page-object.js';
+
+export class GameListPage extends PageObject {
+
+  constructor(options: PageOptions = {}) {
+    super({
+      ...options,
+      scenarioName: 'viewGames',
+      route: 'viewGames?team=test_team1'
+    });
+  }
+
+}

--- a/test/integration/pages/home-page.ts
+++ b/test/integration/pages/home-page.ts
@@ -18,7 +18,7 @@ export class HomePage extends PageObject {
       route: options.route ??
         (options.emptyRoute ? '' : HomePage.defaultRoute),
       scenarioName: options.scenarioName ??
-        (options.openDrawer ? 'navigation-drawer' : HomePage.defaultRoute)
+        (options.openDrawer ? 'navigation-drawer' : '')
     });
     this.showDrawerOnOpen = !!options.openDrawer;
   }

--- a/test/integration/pages/home-page.ts
+++ b/test/integration/pages/home-page.ts
@@ -4,16 +4,23 @@
 
 import { PageObject, PageOpenFunction, PageOptions } from './page-object.js';
 
+export interface HomePageOptions extends PageOptions {
+  openDrawer?: boolean;
+  emptyRoute?: boolean;
+}
+
 export class HomePage extends PageObject {
   private showDrawerOnOpen = false;
 
-  constructor(options: PageOptions = {}, openDrawer = false) {
+  constructor(options: HomePageOptions = {}) {
     super({
       ...options,
-      route: HomePage.defaultRoute,
-      scenarioName: options.scenarioName ?? (openDrawer ? 'navigation-drawer' : '')
+      route: options.route ??
+        (options.emptyRoute ? '' : HomePage.defaultRoute),
+      scenarioName: options.scenarioName ??
+        (options.openDrawer ? 'navigation-drawer' : HomePage.defaultRoute)
     });
-    this.showDrawerOnOpen = openDrawer;
+    this.showDrawerOnOpen = !!options.openDrawer;
   }
 
   static get defaultRoute(): string {

--- a/test/integration/pages/page-object.ts
+++ b/test/integration/pages/page-object.ts
@@ -103,7 +103,7 @@ export class PageObject {
   }
 
   async screenshot(directory?: string): Promise<string> {
-    const viewName = this.scenarioName || this._route || 'index';
+    const viewName = this.scenarioName || this._route || 'unknown';
     const params: ScreenshotOptions = {
       path: path.join(directory || '', `${viewName}.png`)
     };

--- a/test/integration/screenshots-baseline/regenerate.ts
+++ b/test/integration/screenshots-baseline/regenerate.ts
@@ -12,16 +12,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import * as fs from 'fs';
 import * as path from 'path';
-import puppeteer, { Browser, Page, Viewport } from 'puppeteer';
+import { Viewport } from 'puppeteer';
+import { ErrorPage } from '../pages/error-page.js';
+import { GameDetailPage } from '../pages/game-detail-page.js';
+import { GameListPage } from '../pages/game-list-page.js';
 import { HomePage, HomePageOptions } from '../pages/home-page.js';
 import { PageObject, PageOptions } from '../pages/page-object.js';
 import { TeamCreatePage } from '../pages/team-create-page.js';
+import { TeamRosterPage } from '../pages/team-roster-page.js';
 import { TeamSelectPage } from '../pages/team-select-page.js';
-import { serveHermeticFont } from '../server/hermetic-fonts.js';
 import { config, DevServer, startTestServer } from '../server/test-server.js';
 
 describe('🎁 regenerate screenshots', function () {
-  let server: DevServer, browser: Browser, page: Page;
+  let server: DevServer;
 
   before(async function () {
     server = await startTestServer();
@@ -41,31 +44,12 @@ describe('🎁 regenerate screenshots', function () {
 
   after(async () => server.stop());
 
-  beforeEach(async function () {
-    browser = await puppeteer.launch({ args: ['--disable-gpu', '--font-render-hinting=none'] });
-    page = await browser.newPage();
-
-    page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
-
-    page.setRequestInterception(true);
-    page.on('request', async (request) => {
-      const fontResponse = serveHermeticFont(request, config.dataDir);
-      if (fontResponse) {
-        request.respond(fontResponse);
-      } else {
-        request.continue();
-      }
-    });
-  });
-
-  afterEach(() => browser.close());
-
   for (const breakpoint of config.breakpoints) {
     const prefix = breakpoint.name;
     const pageOptions: PageOptions = { viewPort: breakpoint.viewPort };
 
     it(`views - ${prefix}`, async function () {
-      return generateBaselineScreenshots(page, prefix, breakpoint.viewPort);
+      return generateBaselineScreenshots(prefix, breakpoint.viewPort);
     });
 
     if (prefix === 'narrow') {
@@ -88,44 +72,31 @@ describe('🎁 regenerate screenshots', function () {
   }
 });
 
-async function generateBaselineScreenshots(page: Page, prefix: string, breakpoint: Viewport) {
+async function generateBaselineScreenshots(prefix: string, breakpoint: Viewport) {
   console.log(prefix + '...');
-  page.setViewport(breakpoint);
+  const pageOptions: PageOptions = { viewPort: breakpoint };
   // Index.
-  await page.goto(`${config.appUrl}/?test_data`);
-  await page.waitFor(1000);
-  await page.screenshot({ path: `${config.baselineDir}/${prefix}/index.png` });
+  const indexOptions: HomePageOptions = {
+    ...pageOptions,
+    scenarioName: 'index',
+    emptyRoute: true
+  };
+  const indexPage = new HomePage(indexOptions);
+  await generateScreenshot(indexPage, prefix);
   // Views.
-  const views = [
-    { name: 'Home', wait: 1000 },
-    // TODO: Remove sleep hack to avoid blank page in screenshot
-    { name: 'GameDetail', route: 'game/test_game1', setTeam: true, wait: 1000 },
-    // TODO: Remove sleep hack to avoid missing icon on FAB in screenshot
-    { name: 'Games', setTeam: true, wait: 1000 },
-    // TODO: Remove sleep hack to avoid blank page in screenshot
-    { name: 'Roster', setTeam: true, wait: 1000 }
-  ];
-  for (const view of views) {
-    let route = view.route ? view.route : `view${view.name}`;
-    if (view.setTeam) {
-      route += '?team=test_team1';
-    }
-    console.log(`View: ${view.name}, route: ${route}`);
-    const testFlagSeparator = (route && route.includes('?')) ? '&' : '?';
-    await page.goto(`${config.appUrl}/${route}${testFlagSeparator}test_data`);
-    if (view.wait) {
-      console.log(`Wait extra for ${view.name} view`);
-      await page.waitFor(view.wait);
-    }
-    console.log(`Screenshot for view: ${view.name}`);
-    await page.screenshot({ path: `${config.baselineDir}/${prefix}/view${view.name}.png` });
-  }
+  const homePage = new HomePage(pageOptions);
+  await generateScreenshot(homePage, prefix);
+  const gamePage = new GameDetailPage(pageOptions);
+  await generateScreenshot(gamePage, prefix);
+  const gamesPage = new GameListPage(pageOptions);
+  await generateScreenshot(gamesPage, prefix);
+  const rosterPage = new TeamRosterPage(pageOptions);
+  await generateScreenshot(rosterPage, prefix);
   // 404.
   console.log(`Screenshot for 404`);
-  await page.goto(`${config.appUrl}/batmanNotAView?test_data`);
-  console.log(`Wait extra for 404 view`);
-  await page.waitFor(1000);
-  await page.screenshot({ path: `${config.baselineDir}/${prefix}/batmanNotAView.png` });
+  const errorOptions = { ...pageOptions, route: 'batmanNotAView' };
+  const error404Page = new ErrorPage(errorOptions);
+  await generateScreenshot(error404Page, prefix);
 }
 
 async function generateScreenshot(page: PageObject, filePrefix: string) {

--- a/test/integration/screenshots-baseline/regenerate.ts
+++ b/test/integration/screenshots-baseline/regenerate.ts
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import * as fs from 'fs';
 import * as path from 'path';
 import puppeteer, { Browser, Page, Viewport } from 'puppeteer';
-import { HomePage } from '../pages/home-page.js';
+import { HomePage, HomePageOptions } from '../pages/home-page.js';
 import { PageObject, PageOptions } from '../pages/page-object.js';
 import { TeamCreatePage } from '../pages/team-create-page.js';
 import { TeamSelectPage } from '../pages/team-select-page.js';
@@ -70,7 +70,8 @@ describe('🎁 regenerate screenshots', function () {
 
     if (prefix === 'narrow') {
       it('navigation drawer', async function () {
-        const homePage = new HomePage(pageOptions, true);
+        const homeOptions: HomePageOptions = { ...pageOptions, openDrawer: true };
+        const homePage = new HomePage(homeOptions);
         return generateScreenshot(homePage, prefix);
       });
     }

--- a/test/integration/screenshots-baseline/regenerate.ts
+++ b/test/integration/screenshots-baseline/regenerate.ts
@@ -60,18 +60,12 @@ describe('🎁 regenerate screenshots', function () {
 
   afterEach(() => browser.close());
 
-  const breakpoints: Viewport[] = [
-    { width: 800, height: 600 },
-    { width: 375, height: 667 }];
-  const prefixes = ['wide', 'narrow'];
-
-  for (let i = 0; i < prefixes.length; i++) {
-    const prefix = prefixes[i];
-    const breakpoint = breakpoints[i];
-    const pageOptions: PageOptions = { viewPort: breakpoint };
+  for (const breakpoint of config.breakpoints) {
+    const prefix = breakpoint.name;
+    const pageOptions: PageOptions = { viewPort: breakpoint.viewPort };
 
     it(`views - ${prefix}`, async function () {
-      return generateBaselineScreenshots(page, prefix, breakpoint);
+      return generateBaselineScreenshots(page, prefix, breakpoint.viewPort);
     });
 
     if (prefix === 'narrow') {

--- a/test/integration/server/test-server.ts
+++ b/test/integration/server/test-server.ts
@@ -2,13 +2,20 @@ import * as os from 'os';
 import * as path from 'path';
 import { startDevServer } from '@web/dev-server';
 import { DevServer } from '@web/dev-server-core';
+import { Viewport } from 'puppeteer';
 export { DevServer };
+
+export interface BreakpointConfig {
+  name: string;
+  viewPort: Viewport;
+}
 
 export interface IntegrationConfig {
   appUrl: string;
   dataDir: string;
   currentDir: string;
   baselineDir: string;
+  breakpoints: BreakpointConfig[];
 }
 
 let platformName = os.type().toLowerCase();
@@ -25,6 +32,10 @@ export const config: IntegrationConfig = {
   dataDir: path.join(integrationDir, 'data'),
   currentDir: path.join(integrationDir, 'screenshots-current', platformName),
   baselineDir: path.join(integrationDir, 'screenshots-baseline', platformName),
+  breakpoints: [
+    { name: 'wide', viewPort: { width: 800, height: 600 } },
+    { name: 'narrow', viewPort: { width: 375, height: 667 } },
+  ]
 }
 
 export async function startTestServer(): Promise<DevServer> {

--- a/test/integration/visual.ts
+++ b/test/integration/visual.ts
@@ -15,13 +15,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
-import puppeteer, { Browser, HTTPRequest, Page } from 'puppeteer';
-import { HomePage } from './pages/home-page.js';
+import { ErrorPage } from './pages/error-page.js';
+import { GameDetailPage } from './pages/game-detail-page.js';
+import { GameListPage } from './pages/game-list-page.js';
+import { HomePage, HomePageOptions } from './pages/home-page.js';
 import { PageObject, PageOptions } from './pages/page-object.js';
 import { TeamCreatePage } from './pages/team-create-page.js';
 import { TeamRosterPage } from './pages/team-roster-page.js';
 import { TeamSelectPage } from './pages/team-select-page.js';
-import { serveHermeticFont } from './server/hermetic-fonts.js';
 import { config, DevServer, startTestServer } from './server/test-server.js';
 
 function getBaselineFile(view: string) {
@@ -33,7 +34,7 @@ function getCurrentFile(view: string) {
 }
 
 describe('👀 page screenshots are correct', function () {
-  let server: DevServer, browser: Browser, page: Page;
+  let server: DevServer;
   let pageObject: PageObject;
 
   before(async function () {
@@ -50,31 +51,7 @@ describe('👀 page screenshots are correct', function () {
 
   after(async () => await server.stop());
 
-  beforeEach(async function () {
-    browser = await puppeteer.launch({ args: ['--disable-gpu', '--font-render-hinting=none'] });
-    page = await browser.newPage();
-
-    page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
-
-    page.on('requestfailed', (request: HTTPRequest) => {
-      console.log('PAGE REQUEST FAIL: [' + request.url() + '] ' + request.failure()!.errorText);
-    });
-
-    page.setRequestInterception(true);
-    page.on('request', async (request: HTTPRequest) => {
-      const fontResponse = serveHermeticFont(request, config.dataDir);
-      if (fontResponse) {
-        request.respond(fontResponse);
-      } else {
-        request.continue();
-      }
-    });
-
-    await page.emulateTimezone('America/Toronto');
-  });
-
   afterEach(async () => {
-    await browser.close();
     await pageObject?.close();
   });
 
@@ -83,76 +60,60 @@ describe('👀 page screenshots are correct', function () {
       const prefix = breakpoint.name;
       const pageOptions: PageOptions = { viewPort: breakpoint.viewPort };
 
-      beforeEach(async function () {
-        return page.setViewport(breakpoint.viewPort);
-      });
-
       it('/index.html', async function () {
-        return takeAndCompareScreenshot(page, '', prefix);
+        const indexOptions: HomePageOptions = { ...pageOptions, emptyRoute: true };
+        const homePage = pageObject = new HomePage(indexOptions);
+        return takeAndCompareScreenshot(homePage, prefix);
       });
       it('/viewHome', async function () {
         const homePage = pageObject = new HomePage(pageOptions);
-        return takeAndCompareScreenshot(homePage, 'viewHome', prefix);
+        return takeAndCompareScreenshot(homePage, prefix);
       });
       if (prefix === 'narrow') {
         it('navigation drawer', async function () {
-          const homePage = pageObject = new HomePage(pageOptions, true);
-          return takeAndCompareScreenshot(homePage, '', prefix);
+          const homeOptions: HomePageOptions = { ...pageOptions, openDrawer: true };
+          const homePage = pageObject = new HomePage(homeOptions);
+          return takeAndCompareScreenshot(homePage, prefix);
         });
       }
       it('/viewGames', async function () {
-        return takeAndCompareScreenshot(page, 'viewGames?team=test_team1', prefix, 'viewGames', null, 'lineup-view-games');
+        const gamesPage = pageObject = new GameListPage(pageOptions);
+        return takeAndCompareScreenshot(gamesPage, prefix);
       });
       it('/viewRoster', async function () {
         const rosterPage = pageObject = new TeamRosterPage(pageOptions);
-        return takeAndCompareScreenshot(rosterPage, 'viewRoster?team=test_team1', prefix, 'viewRoster', null, 'lineup-view-roster');
+        return takeAndCompareScreenshot(rosterPage, prefix);
       });
       it('/404', async function () {
-        return takeAndCompareScreenshot(page, 'batmanNotAView', prefix);
+        const errorOptions = { ...pageOptions, route: 'batmanNotAView' };
+        const error404Page = pageObject = new ErrorPage(errorOptions);
+        return takeAndCompareScreenshot(error404Page, prefix);
       });
 
       it('add new team', async function () {
         const addTeamPage = pageObject = new TeamCreatePage(pageOptions);
-        return takeAndCompareScreenshot(addTeamPage, '', prefix);
+        return takeAndCompareScreenshot(addTeamPage, prefix);
       });
 
       it('select team', async function () {
         const selectTeamPage = pageObject = new TeamSelectPage(pageOptions);
-        return takeAndCompareScreenshot(selectTeamPage, '', prefix);
+        return takeAndCompareScreenshot(selectTeamPage, prefix);
       });
 
       it('/game', async function () {
-        return takeAndCompareScreenshot(page, 'game/test_game1?team=test_team1', prefix, 'viewGameDetail', null, 'lineup-view-game-detail');
+        const gamePage = pageObject = new GameDetailPage(pageOptions);
+        return takeAndCompareScreenshot(gamePage, prefix);
       });
     }); // describe(`${breakpoint.name} screen`)
   }
 });
 
-async function takeAndCompareScreenshot(page: Page | PageObject, route: string, filePrefix: string, setupName?: string, setup?: any, waitForSelector?: any) {
-  if (page instanceof PageObject) {
-    await page.init();
-    await page.open();
-    const viewName = await page.screenshot(path.join(config.currentDir, filePrefix));
-    // TODO: Pass filePrefix as an explicit parameter.
-    return compareScreenshots(path.join(filePrefix, viewName));
-  }
-
-  // If you didn't specify a file, use the name of the route.
-  const fileName = path.join(filePrefix, (setupName ? setupName : (route ? route : 'index')));
-
-  const testFlagSeparator = (route && route.includes('?')) ? '&' : '?';
-  await page.goto(`${config.appUrl}/${route}${testFlagSeparator}test_data`);
-  if (setup) {
-    await setup(page);
-  }
-  // TODO: Figure out all screenshots take longer on linux
-  // eslint-disable-next-line no-constant-condition
-  if (waitForSelector || true) { // waitForSelector) {
-    // await page.waitForSelector(waitForSelector);
-    await page.waitFor(1500);
-  }
-  await page.screenshot({ path: getCurrentFile(fileName) });
-  return compareScreenshots(fileName);
+async function takeAndCompareScreenshot(page: PageObject, filePrefix: string) {
+  await page.init();
+  await page.open();
+  const viewName = await page.screenshot(path.join(config.currentDir, filePrefix));
+  // TODO: Pass filePrefix as an explicit parameter.
+  return compareScreenshots(path.join(filePrefix, viewName));
 }
 
 function compareScreenshots(view: string) {

--- a/test/integration/visual.ts
+++ b/test/integration/visual.ts
@@ -61,7 +61,11 @@ describe('👀 page screenshots are correct', function () {
       const pageOptions: PageOptions = { viewPort: breakpoint.viewPort };
 
       it('/index.html', async function () {
-        const indexOptions: HomePageOptions = { ...pageOptions, emptyRoute: true };
+        const indexOptions: HomePageOptions = {
+          ...pageOptions,
+          scenarioName: 'index',
+          emptyRoute: true
+        };
         const homePage = pageObject = new HomePage(indexOptions);
         return takeAndCompareScreenshot(homePage, prefix);
       });

--- a/test/integration/visual.ts
+++ b/test/integration/visual.ts
@@ -12,7 +12,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import { expect } from 'chai';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
@@ -25,30 +24,12 @@ import { TeamSelectPage } from './pages/team-select-page.js';
 import { serveHermeticFont } from './server/hermetic-fonts.js';
 import { config, DevServer, startTestServer } from './server/test-server.js';
 
-
-let platformName = os.type().toLowerCase();
-if (platformName === 'darwin') {
-  platformName = 'macos';
-} else if (os.hostname() === 'penguin') {
-  platformName = 'chromeos';
-}
-
-const integrationDir = path.join(process.cwd(), 'test/integration');
-const dataDir = path.join(integrationDir, 'data');
-const currentDir = path.join(integrationDir, 'screenshots-current', platformName);
-const baselineDir = path.join(integrationDir, 'screenshots-baseline', platformName);
-
-const breakpoints = [
-  { name: 'wide', viewPort: { width: 800, height: 600 } },
-  { name: 'narrow', viewPort: { width: 375, height: 667 } },
-];
-
 function getBaselineFile(view: string) {
-  return path.join(baselineDir, `${view}.png`);
+  return path.join(config.baselineDir, `${view}.png`);
 }
 
 function getCurrentFile(view: string) {
-  return path.join(currentDir, `${view}.png`);
+  return path.join(config.currentDir, `${view}.png`);
 }
 
 describe('👀 page screenshots are correct', function () {
@@ -59,8 +40,8 @@ describe('👀 page screenshots are correct', function () {
     server = await startTestServer();
 
     // Create the test directories if needed.
-    for (const breakpoint of breakpoints) {
-      const dir = path.join(currentDir, breakpoint.name);
+    for (const breakpoint of config.breakpoints) {
+      const dir = path.join(config.currentDir, breakpoint.name);
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
       }
@@ -81,7 +62,7 @@ describe('👀 page screenshots are correct', function () {
 
     page.setRequestInterception(true);
     page.on('request', async (request: HTTPRequest) => {
-      const fontResponse = serveHermeticFont(request, dataDir);
+      const fontResponse = serveHermeticFont(request, config.dataDir);
       if (fontResponse) {
         request.respond(fontResponse);
       } else {
@@ -97,7 +78,7 @@ describe('👀 page screenshots are correct', function () {
     await pageObject?.close();
   });
 
-  for (const breakpoint of breakpoints) {
+  for (const breakpoint of config.breakpoints) {
     describe(`${breakpoint.name} screen`, function () {
       const prefix = breakpoint.name;
       const pageOptions: PageOptions = { viewPort: breakpoint.viewPort };
@@ -151,7 +132,7 @@ async function takeAndCompareScreenshot(page: Page | PageObject, route: string, 
   if (page instanceof PageObject) {
     await page.init();
     await page.open();
-    const viewName = await page.screenshot(path.join(currentDir, filePrefix));
+    const viewName = await page.screenshot(path.join(config.currentDir, filePrefix));
     // TODO: Pass filePrefix as an explicit parameter.
     return compareScreenshots(path.join(filePrefix, viewName));
   }


### PR DESCRIPTION
- Remove the hard-coded puppeteer logic in favour of the encapsulated page objects
- Also use page objects for generating the baseline screenshots