### PR TITLE
Use lit-router for routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "lineup-tracker",
       "dependencies": {
         "@lit-labs/context": "^0.1.3",
+        "@lit-labs/router": "^0.1.1",
         "@material/mwc-button": "^0.27.0",
         "@material/mwc-checkbox": "^0.27.0",
         "@material/mwc-circular-progress": "^0.27.0",
@@ -2846,6 +2847,14 @@
       "dependencies": {
         "@lit/reactive-element": "^1.0.0",
         "lit": "^2.0.0"
+      }
+    },
+    "node_modules/@lit-labs/router": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/router/-/router-0.1.1.tgz",
+      "integrity": "sha512-B2WYOXmI1vXAZKKkfGWDhe/Ki8W7ZsopFx7uD9ZvdaEFbFjxzqcmBGoK5v2RX1jceG1lmDfdHvCGyXxiy1zqYg==",
+      "dependencies": {
+        "lit": "^2.1.0"
       }
     },
     "node_modules/@lit/reactive-element": {
@@ -24236,6 +24245,14 @@
       "requires": {
         "@lit/reactive-element": "^1.0.0",
         "lit": "^2.0.0"
+      }
+    },
+    "@lit-labs/router": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/router/-/router-0.1.1.tgz",
+      "integrity": "sha512-B2WYOXmI1vXAZKKkfGWDhe/Ki8W7ZsopFx7uD9ZvdaEFbFjxzqcmBGoK5v2RX1jceG1lmDfdHvCGyXxiy1zqYg==",
+      "requires": {
+        "lit": "^2.1.0"
       }
     },
     "@lit/reactive-element": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@lit-labs/context": "^0.1.3",
+    "@lit-labs/router": "^0.1.1",
     "@material/mwc-button": "^0.27.0",
     "@material/mwc-checkbox": "^0.27.0",
     "@material/mwc-circular-progress": "^0.27.0",

--- a/src/components/lineup-app.ts
+++ b/src/components/lineup-app.ts
@@ -16,7 +16,6 @@ import { User } from '../models/auth';
 import { Team, Teams } from '../models/team.js';
 import { currentTeamChanged, offlineChanged, selectCurrentTeam, updateDrawerState, updatePage } from '../slices/app/app-slice.js';
 import { auth, signIn } from '../slices/auth/auth-slice.js';
-import { getGameStore } from '../slices/game-store.js';
 import { getTeams, selectTeamsLoaded, team } from '../slices/team/team-slice.js';
 import { RootState, store } from '../store';
 import { accountIcon } from './lineup-icons';
@@ -338,14 +337,11 @@ export class LineupApp extends connect(store)(LitElement) {
     },
     {
       name: 'game', path: '/game/:gameId',
-      render: () => html`<lineup-view-game-detail class="page" active></lineup-view-game-detail>`,
+      render: ({ gameId }) => html`<lineup-view-game-detail gameId="${ifDefined(gameId)}" class="page" active></lineup-view-game-detail>`,
       enter: async ({ gameId }) => {
-        const detailModule = await import('./lineup-view-game-detail.js');
-        // Fetch the data for the given game id.
+        await import('./lineup-view-game-detail.js');
         console.log(`loading game detail page for ${gameId}`);
-        getGameStore(store);
-        await store.dispatch(detailModule.getGame(gameId!));
-        return this.navigateToPage('game')
+        return this.navigateToPage('game');
       },
     },
     {
@@ -354,7 +350,7 @@ export class LineupApp extends connect(store)(LitElement) {
       enter: async ({ gameId }) => {
         await import('./lineup-view-game-roster.js');
         console.log(`loading game roster page for ${gameId}`);
-        return this.navigateToPage('gameroster')
+        return this.navigateToPage('gameroster');
       },
     },
     {

--- a/src/components/lineup-app.ts
+++ b/src/components/lineup-app.ts
@@ -350,13 +350,10 @@ export class LineupApp extends connect(store)(LitElement) {
     },
     {
       name: 'gameroster', path: '/gameroster/:gameId',
-      render: () => html`<lineup-view-game-roster class="page" active></lineup-view-game-roster>`,
+      render: ({ gameId }) => html`<lineup-view-game-roster gameId="${ifDefined(gameId)}" class="page" active></lineup-view-game-roster>`,
       enter: async ({ gameId }) => {
-        const rosterModule = await import('./lineup-view-game-roster.js');
-        // Fetch the data for the given game id.
+        await import('./lineup-view-game-roster.js');
         console.log(`loading game roster page for ${gameId}`);
-        getGameStore(store);
-        await store.dispatch(rosterModule.getGame(gameId!));
         return this.navigateToPage('gameroster')
       },
     },

--- a/src/components/lineup-game-setup.ts
+++ b/src/components/lineup-game-setup.ts
@@ -1,7 +1,3 @@
-/**
-@license
-*/
-
 import '@material/mwc-button';
 import '@material/mwc-icon';
 import { html, LitElement, nothing } from 'lit';
@@ -12,7 +8,6 @@ import { connectStore } from '../middleware/connect-mixin';
 import { FormationBuilder, FormationMetadata, formatPosition, Position } from '../models/formation';
 import { GameDetail, SetupStatus, SetupSteps, SetupTask } from '../models/game.js';
 import { LivePlayer } from '../models/live.js';
-import { navigate } from '../slices/app/app-slice.js';
 import { getGameStore } from '../slices/game-store';
 import { gameSetupCompletedCreator } from '../slices/game/game-slice.js';
 import { getLiveStore } from '../slices/live-store';
@@ -276,8 +271,8 @@ export class LineupGameSetup extends connectStore()(LitElement) {
           break;
 
         case SetupSteps.Roster:
+          // TODO: Pass router via context?
           window.history.pushState({}, '', `/gameroster/${this.game!.id}`);
-          this.dispatch(navigate(window.location));
           break;
 
         default:

--- a/src/components/lineup-game-setup.ts
+++ b/src/components/lineup-game-setup.ts
@@ -1,3 +1,4 @@
+import { contextProvided } from '@lit-labs/context';
 import '@material/mwc-button';
 import '@material/mwc-icon';
 import { html, LitElement, nothing } from 'lit';
@@ -20,6 +21,7 @@ import {
 import { RootState, RootStore, SliceStoreConfigurator } from '../store';
 import './lineup-on-player-list';
 import './lineup-player-list';
+import { PageRouter, pageRouterContext } from './page-router.js';
 import { SharedStyles } from './shared-styles';
 
 function getStepName(step: SetupSteps): string {
@@ -197,6 +199,10 @@ export class LineupGameSetup extends connectStore()(LitElement) {
   @property({ type: Object })
   storeConfigurator?: SliceStoreConfigurator = getLiveStore;
 
+  @contextProvided({ context: pageRouterContext, subscribe: true })
+  @property({ attribute: false })
+  pageRouter!: PageRouter;
+
   @state()
   private game: GameDetail | undefined;
 
@@ -271,8 +277,8 @@ export class LineupGameSetup extends connectStore()(LitElement) {
           break;
 
         case SetupSteps.Roster:
-          // TODO: Pass router via context?
-          window.history.pushState({}, '', `/gameroster/${this.game!.id}`);
+          // TODO: Pass page and params separately
+          this.pageRouter.gotoPage(`/gameroster/${this.game!.id}`);
           break;
 
         default:

--- a/src/components/lineup-view-game-detail.ts
+++ b/src/components/lineup-view-game-detail.ts
@@ -1,5 +1,5 @@
 import '@material/mwc-button';
-import { html, LitElement } from 'lit';
+import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { updateMetadata } from 'pwa-helpers/metadata.js';
 import { connectStore } from '../middleware/connect-mixin';
@@ -9,11 +9,11 @@ import { getGame, selectGameById } from '../slices/game/game-slice.js';
 import { RootState, RootStore, SliceStoreConfigurator } from '../store';
 import './lineup-game-live';
 import './lineup-game-setup';
-import { PageViewMixin } from './page-view-element.js';
+import { PageViewElement } from './page-view-element.js';
 import { SharedStyles } from './shared-styles';
 
 @customElement('lineup-view-game-detail')
-export class LineupViewGameDetail extends connectStore()(PageViewMixin(LitElement)) {
+export class LineupViewGameDetail extends connectStore()(PageViewElement) {
   private _getDetailContent(game: GameDetail) {
     if (game.status === GameStatus.Done) {
       // Completed game

--- a/src/components/lineup-view-game-detail.ts
+++ b/src/components/lineup-view-game-detail.ts
@@ -1,22 +1,19 @@
-import { html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import '@material/mwc-button';
+import { html, LitElement } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
 import { updateMetadata } from 'pwa-helpers/metadata.js';
 import { connectStore } from '../middleware/connect-mixin';
 import { GameDetail, GameStatus } from '../models/game.js';
+import { getGameStore } from '../slices/game-store.js';
+import { getGame, selectGameById } from '../slices/game/game-slice.js';
 import { RootState, RootStore, SliceStoreConfigurator } from '../store';
-import { PageViewElement } from './page-view-element.js';
-// The game-specific store configurator, which handles initialization/lazy-loading.
-import '@material/mwc-button';
-import { getGameStore } from '../slices/game-store';
 import './lineup-game-live';
 import './lineup-game-setup';
+import { PageViewMixin } from './page-view-element.js';
 import { SharedStyles } from './shared-styles';
 
-// Expose action for use in loading view.
-export { getGame } from '../slices/game/game-slice.js';
-
 @customElement('lineup-view-game-detail')
-export class LineupViewGameDetail extends connectStore()(PageViewElement) {
+export class LineupViewGameDetail extends connectStore()(PageViewMixin(LitElement)) {
   private _getDetailContent(game: GameDetail) {
     if (game.status === GameStatus.Done) {
       // Completed game
@@ -33,7 +30,7 @@ export class LineupViewGameDetail extends connectStore()(PageViewElement) {
   }
 
   override render() {
-    if (this._game) {
+    if (this.game) {
       updateMetadata({
         title: `Game - ${this._getName()}`,
         description: `Game details for: ${this._getName()}`
@@ -43,9 +40,9 @@ export class LineupViewGameDetail extends connectStore()(PageViewElement) {
     return html`
       ${SharedStyles}
       <section>
-      ${this._game ? html`
+      ${this.game ? html`
         <h2 main-title>Live: ${this._getName()}</h2>
-        ${this._getDetailContent(this._game)}
+        ${this._getDetailContent(this.game)}
       ` : html`
         <p class="empty-list">
           Game not found.
@@ -61,22 +58,44 @@ export class LineupViewGameDetail extends connectStore()(PageViewElement) {
   @property({ type: Object })
   storeConfigurator?: SliceStoreConfigurator = getGameStore;
 
-  @property({ type: Object })
-  private _game: GameDetail | undefined;
+  @property({ type: String })
+  gameId?: string;
+
+  @state()
+  private game?: GameDetail;
+
+  private gameLoaded = false;
 
   override stateChanged(state: RootState) {
-    if (!state.game) {
+    if (!this.gameId) {
       return;
     }
-    const gameState = state.game!;
-    this._game = gameState.game;
+    this.game = selectGameById(state, this.gameId);
+    this.gameLoaded = !!this.game?.hasDetail;
+  }
+
+  protected override keyPropertyName = 'gameId';
+
+  protected override loadData() {
+    if (this.gameId) {
+      this.dispatch(getGame(this.gameId));
+    }
+  }
+
+  protected override resetDataProperties() {
+    this.gameLoaded = false;
+    this.game = undefined;
+  }
+
+  protected override isDataReady() {
+    return this.gameLoaded;
   }
 
   private _getName() {
     const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
       'Sep', 'Oct', 'Nov', 'Dec'
     ];
-    const game = this._game!;
+    const game = this.game!;
     return game.opponent + ' ' + monthNames[game.date.getMonth()] + ' ' +
       game.date.getDate();
   }

--- a/src/components/lineup-view-game-roster.ts
+++ b/src/components/lineup-view-game-roster.ts
@@ -13,7 +13,6 @@ import './lineup-roster.js';
 import { PageViewMixin } from './page-view-element.js';
 import { SharedStyles } from './shared-styles.js';
 
-
 // This element is connected to the Redux store.
 @customElement('lineup-view-game-roster')
 export class LineupViewGameRoster extends connectStore()(PageViewMixin(LitElement)) {

--- a/src/components/lineup-view-game-roster.ts
+++ b/src/components/lineup-view-game-roster.ts
@@ -1,6 +1,6 @@
 import '@material/mwc-button';
 import '@material/mwc-circular-progress';
-import { html, LitElement, nothing } from 'lit';
+import { html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { updateMetadata } from 'pwa-helpers/metadata.js';
 import { connectStore } from '../middleware/connect-mixin';
@@ -10,12 +10,12 @@ import { getGameStore } from '../slices/game-store.js';
 import { addNewGamePlayer, copyRoster, getGame, selectGameById, selectGameRosterLoading } from '../slices/game/game-slice.js';
 import { RootState, RootStore, SliceStoreConfigurator } from '../store.js';
 import './lineup-roster.js';
-import { PageViewMixin } from './page-view-element.js';
+import { PageViewElement } from './page-view-element.js';
 import { SharedStyles } from './shared-styles.js';
 
 // This element is connected to the Redux store.
 @customElement('lineup-view-game-roster')
-export class LineupViewGameRoster extends connectStore()(PageViewMixin(LitElement)) {
+export class LineupViewGameRoster extends connectStore()(PageViewElement) {
   // TODO: Extract common logic (duplicated from LineupViewGameDetail)
   override render() {
     let gameExists = false;

--- a/src/components/lineup-view-game-roster.ts
+++ b/src/components/lineup-view-game-roster.ts
@@ -1,6 +1,6 @@
 import '@material/mwc-button';
 import '@material/mwc-circular-progress';
-import { html, LitElement, nothing, PropertyValues } from 'lit';
+import { html, LitElement, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { updateMetadata } from 'pwa-helpers/metadata.js';
 import { connectStore } from '../middleware/connect-mixin';
@@ -13,8 +13,6 @@ import './lineup-roster.js';
 import { PageViewMixin } from './page-view-element.js';
 import { SharedStyles } from './shared-styles.js';
 
-// Expose action for use in loading view.
-export { getGame } from '../slices/game/game-slice.js';
 
 // This element is connected to the Redux store.
 @customElement('lineup-view-game-roster')
@@ -105,14 +103,11 @@ export class LineupViewGameRoster extends connectStore()(PageViewMixin(LitElemen
     this._copyingInProgress = !!selectGameRosterLoading(state);
   }
 
-  override willUpdate(changedProperties: PropertyValues<this>) {
-    super.willUpdate(changedProperties);
-    if (changedProperties.has('gameId')) {
-      this.resetData();
-      if (this.gameId) {
-        this.dispatch(getGame(this.gameId));
-      }
-      return;
+  protected override keyPropertyName = 'gameId';
+
+  protected override loadData() {
+    if (this.gameId) {
+      this.dispatch(getGame(this.gameId));
     }
   }
 

--- a/src/components/lineup-view-game-roster.ts
+++ b/src/components/lineup-view-game-roster.ts
@@ -1,17 +1,17 @@
 import '@material/mwc-button';
 import '@material/mwc-circular-progress';
-import { html, nothing } from 'lit';
+import { html, nothing, PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { updateMetadata } from 'pwa-helpers/metadata.js';
 import { connectStore } from '../middleware/connect-mixin';
-import { GameDetail, GameStatus } from '../models/game';
-import { Roster } from '../models/player';
-import { getGameStore } from '../slices/game-store';
-import { addNewGamePlayer, copyRoster } from '../slices/game/game-slice.js';
-import { RootState, RootStore, SliceStoreConfigurator } from '../store';
-import './lineup-roster';
-import { PageViewElement } from './page-view-element';
-import { SharedStyles } from './shared-styles';
+import { GameDetail, GameStatus } from '../models/game.js';
+import { Roster } from '../models/player.js';
+import { getGameStore } from '../slices/game-store.js';
+import { addNewGamePlayer, copyRoster, getGame, selectGameById, selectGameRosterLoading } from '../slices/game/game-slice.js';
+import { RootState, RootStore, SliceStoreConfigurator } from '../store.js';
+import './lineup-roster.js';
+import { PageViewElement } from './page-view-element.js';
+import { SharedStyles } from './shared-styles.js';
 
 // Expose action for use in loading view.
 export { getGame } from '../slices/game/game-slice.js';
@@ -21,12 +21,13 @@ export { getGame } from '../slices/game/game-slice.js';
 export class LineupViewGameRoster extends connectStore()(PageViewElement) {
   // TODO: Extract common logic (duplicated from LineupViewGameDetail)
   override render() {
-    const gameExists = !!this._game;
+    let gameExists = false;
     let rosterExists = false;
     let isNewStatus = false;
 
-    if (gameExists) {
-      isNewStatus = this._game!.status === GameStatus.New;
+    if (this.game) {
+      gameExists = true;
+      isNewStatus = this.game.status === GameStatus.New;
       rosterExists = (Object.keys(this._roster).length > 0);
 
       updateMetadata({
@@ -49,7 +50,7 @@ export class LineupViewGameRoster extends connectStore()(PageViewElement) {
             <div>Roster is empty.</div>
             <mwc-button id='copy-button' icon="file_copy" ?disabled="${this._copyingInProgress}"
                         @click="${this._copyTeamRoster}">Copy From Team</mwc-button>
-            ${this._getLoadingContent()}
+            ${this.renderCopyingInProgress()}
           </div>
         `}
       ` : html`
@@ -61,7 +62,7 @@ export class LineupViewGameRoster extends connectStore()(PageViewElement) {
     `;
   }
 
-  private _getLoadingContent() {
+  private renderCopyingInProgress() {
     if (!this._copyingInProgress) {
       return nothing;
     }
@@ -80,8 +81,14 @@ export class LineupViewGameRoster extends connectStore()(PageViewElement) {
   @property({ type: Object })
   storeConfigurator?: SliceStoreConfigurator = getGameStore;
 
+  @property({ type: String })
+  gameId?: string;
+
+  @property({ type: Boolean, reflect: true })
+  ready = false;
+
   @state()
-  private _game: GameDetail | undefined;
+  private game?: GameDetail;
 
   @state()
   private _roster: Roster = {};
@@ -89,19 +96,43 @@ export class LineupViewGameRoster extends connectStore()(PageViewElement) {
   @state()
   private _copyingInProgress = false;
 
+  private gameLoaded = false;
+
   override stateChanged(state: RootState) {
-    if (!state.game) {
+    if (!this.gameId) {
       return;
     }
-    const gameState = state.game!;
-    this._game = gameState.game;
-    this._roster = gameState.game && gameState.game.roster || {};
-    this._copyingInProgress = gameState.rosterLoading;
+    this.game = selectGameById(state, this.gameId);
+    this.gameLoaded = !!this.game?.hasDetail;
+    this._roster = this.game?.roster || {};
+    this._copyingInProgress = !!selectGameRosterLoading(state);
+  }
+
+  override willUpdate(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has('gameId')) {
+      this.resetData();
+      if (this.gameId) {
+        this.dispatch(getGame(this.gameId));
+      }
+      return;
+    }
+    if (!this.ready && this.gameLoaded && !this._copyingInProgress) {
+      this.ready = true;
+    }
+  }
+
+  private resetData() {
+    this.ready = false;
+    this.gameLoaded = false;
+    this.game = undefined;
+    this._roster = {};
+    this._copyingInProgress = false;
   }
 
   private _copyTeamRoster(e: Event) {
     if (e.target) { (e.target as HTMLInputElement).disabled = true; }
-    this.dispatch(copyRoster(this._game!.id));
+    this.ready = false;
+    this.dispatch(copyRoster(this.gameId!));
   }
 
   private newPlayerCreated(e: CustomEvent) {
@@ -113,7 +144,7 @@ export class LineupViewGameRoster extends connectStore()(PageViewElement) {
     const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
       'Sep', 'Oct', 'Nov', 'Dec'
     ];
-    const game = this._game!;
+    const game = this.game!;
     return game.opponent + ' ' + monthNames[game.date.getMonth()] + ' ' +
       game.date.getDate();
   }

--- a/src/components/lineup-view-games.ts
+++ b/src/components/lineup-view-games.ts
@@ -1,5 +1,5 @@
 import '@material/mwc-fab';
-import { html, LitElement } from 'lit';
+import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { debug } from '../common/debug.js';
 import { connectStore } from '../middleware/connect-mixin.js';
@@ -10,14 +10,14 @@ import { addNewGame, getGames } from '../slices/game/game-slice.js';
 import { RootState, RootStore, SliceStoreConfigurator } from '../store.js';
 import './lineup-game-create.js';
 import './lineup-game-list.js';
-import { PageViewMixin } from './page-view-element.js';
+import { PageViewElement } from './page-view-element.js';
 import { SharedStyles } from './shared-styles.js';
 
 const debugGames = debug('view-games');
 
 // This element is connected to the Redux store.
 @customElement('lineup-view-games')
-export class LineupViewGames extends connectStore()(PageViewMixin(LitElement)) {
+export class LineupViewGames extends connectStore()(PageViewElement) {
   override render() {
     return html`
       ${SharedStyles}

--- a/src/components/lineup-view-team-create.ts
+++ b/src/components/lineup-view-team-create.ts
@@ -1,11 +1,12 @@
+import { contextProvided } from '@lit-labs/context';
 import { html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { connect } from 'pwa-helpers/connect-mixin.js';
-
 import { addNewTeam, team } from '../slices/team/team-slice.js';
 import { RootState, store } from '../store';
 import { EVENT_NEWTEAMCREATED } from './events';
 import './lineup-team-create';
+import { pageRouterContext, PageRouter } from './page-router.js';
 import { PageViewElement } from './page-view-element';
 import { SharedStyles } from './shared-styles';
 
@@ -27,6 +28,10 @@ export class LineupViewTeamCreate extends connect(store)(PageViewElement) {
     `;
   }
 
+  @contextProvided({ context: pageRouterContext, subscribe: true })
+  @property({ attribute: false })
+  pageRouter!: PageRouter;
+
   override firstUpdated() {
     window.addEventListener(EVENT_NEWTEAMCREATED, this._newTeamCreated.bind(this) as EventListener);
   }
@@ -39,8 +44,8 @@ export class LineupViewTeamCreate extends connect(store)(PageViewElement) {
 
   private _newTeamCreated(e: CustomEvent) {
     store.dispatch(addNewTeam(e.detail.team));
-    // TODO: Pass router via context?
-    window.history.pushState({}, '', `/viewHome`);
+    // TODO: Pass page and params separately
+    this.pageRouter.gotoPage(`/viewHome`);
   }
 
 }

--- a/src/components/lineup-view-team-create.ts
+++ b/src/components/lineup-view-team-create.ts
@@ -1,11 +1,7 @@
-/**
-@license
-*/
-
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { connect } from 'pwa-helpers/connect-mixin.js';
-import { navigate } from '../slices/app/app-slice.js';
+
 import { addNewTeam, team } from '../slices/team/team-slice.js';
 import { RootState, store } from '../store';
 import { EVENT_NEWTEAMCREATED } from './events';
@@ -43,8 +39,8 @@ export class LineupViewTeamCreate extends connect(store)(PageViewElement) {
 
   private _newTeamCreated(e: CustomEvent) {
     store.dispatch(addNewTeam(e.detail.team));
+    // TODO: Pass router via context?
     window.history.pushState({}, '', `/viewHome`);
-    store.dispatch(navigate(window.location));
   }
 
 }

--- a/src/components/page-router.ts
+++ b/src/components/page-router.ts
@@ -1,0 +1,8 @@
+import { createContext } from '@lit-labs/context';
+
+export interface PageRouter {
+  // TODO: Pass page name and params separately
+  gotoPage(pathname: string): Promise<void>;
+}
+
+export const pageRouterContext = createContext<PageRouter>('page-router');

--- a/src/components/page-view-element.ts
+++ b/src/components/page-view-element.ts
@@ -80,12 +80,4 @@ export const PageViewMixin = <T extends Constructor<LitElement>, K extends keyof
   return PageViewClass as unknown as Constructor<PageViewInterface> & T;
 }
 
-export class PageViewElement extends LitElement {
-  // Only render this page if it's actually visible.
-  override shouldUpdate() {
-    return this.active;
-  }
-
-  @property({ type: Boolean })
-  active = false;
-}
+export const PageViewElement = PageViewMixin(LitElement);

--- a/src/components/page-view-element.ts
+++ b/src/components/page-view-element.ts
@@ -12,11 +12,17 @@ export declare class PageViewInterface {
   // Is the element finished loading any data.
   ready: boolean;
   protected resetData(): void;
+
+  // These members are to be overridden.
+  // Name of the property that determines which data is loaded.
+  protected keyPropertyName: string;
+  // Load data in response to a change in the key property.
+  protected loadData(): void;
   protected resetDataProperties(): void;
   protected isDataReady(): boolean;
 }
 
-export const PageViewMixin = <T extends Constructor<LitElement>>(superClass: T) => {
+export const PageViewMixin = <T extends Constructor<LitElement>, K extends keyof T>(superClass: T) => {
   class PageViewClass extends superClass {
 
     @property({ type: Boolean })
@@ -25,13 +31,25 @@ export const PageViewMixin = <T extends Constructor<LitElement>>(superClass: T) 
     @property({ type: Boolean, reflect: true })
     public ready = false;
 
+    protected keyPropertyName?: K;
+
     // Only render this page if it's actually visible.
     override shouldUpdate() {
       return this.active;
     }
 
-    override willUpdate(changedProperties: PropertyValues<this>) {
+    override willUpdate(changedProperties: PropertyValues) {
       super.willUpdate(changedProperties);
+
+      if (this.keyPropertyName && changedProperties.has(this.keyPropertyName)) {
+        // TODO: Find a less hacky way to do this.
+        const keyValue = ((this as any)[this.keyPropertyName]) as string;// this.getKeyProperty();
+        this.resetData();
+        if (keyValue) {
+          this.loadData();
+        }
+        return;
+      }
 
       if (!this.ready && this.isDataReady()) {
         this.ready = true;
@@ -43,6 +61,10 @@ export const PageViewMixin = <T extends Constructor<LitElement>>(superClass: T) 
       this.ready = false;
       this.resetDataProperties();
     }
+
+    // Load data needed to render the element, in response to the key property changing.
+    // To be overridden by the element.
+    protected loadData() { }
 
     // Clear any data properties stored in the element.
     // To be overridden by the element.

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,7 +1,5 @@
-import { installRouter } from 'pwa-helpers/router';
 import { setupAuthListeners, startAppListening } from './app/action-listeners.js';
 import { debug } from './common/debug.js';
-import { navigate } from './slices/app/app-slice.js';
 import { getUser } from './slices/auth/auth-slice.js';
 import { store } from './store.js';
 
@@ -43,14 +41,7 @@ export async function initApp() {
       console.error(`Error initializing teams [${e.name}]: ${e.message}\nat ${e.stack}`);
     }
   }
-  // Set the initialized data flag before installing the router. The router will
-  // load a page, which may depend on the initialization being complete.
   window.document.body.dataset.appInitialized = 'true';
-
-  // Wait for the loading actions to complete (success or error), before any navigation.
-  debugInit(`install router: ${location.href}`);
-  installRouter((location) => store.dispatch(navigate(location)));
-
   appInitialized = true;
   debugInit(`finished\n${JSON.stringify(window.document.body.dataset)}`);
 }

--- a/src/slices/app/app-slice.ts
+++ b/src/slices/app/app-slice.ts
@@ -6,23 +6,7 @@ import { addTeam } from '../team/team-slice.js';
 
 const env = getEnv();
 
-export const navigate = (location: Location): ThunkResult => (dispatch) => {
-  // Extract the page name from path.
-  const pathname = location.pathname;
-  const parts = pathname.slice(1).split('/');
-  let page = parts[0] || 'viewHome';
-
-  console.log(`navigate: got page = ${page} from location`, location.href);
-  // Game views have path: /{view}/{gameId}
-  const gameId = parts[1];
-
-  dispatch(loadPage(page, gameId));
-
-  // Close the drawer - in case the *path* change came from a link in the drawer.
-  dispatch(updateDrawerState(false));
-};
-
-const loadPage = (page: string, gameId: string): ThunkResult => async (dispatch) => {
+export const loadPage = (page: string, gameId?: string): ThunkResult => async (dispatch) => {
   console.log(`loadPage: page = ${page}, gameId = ${gameId}`);
   switch (page) {
     case 'viewHome':
@@ -38,13 +22,13 @@ const loadPage = (page: string, gameId: string): ThunkResult => async (dispatch)
       const detailModule = await import('../../components/lineup-view-game-detail');
       // Fetch the data for the given game id.
       console.log(`loading game detail page for ${gameId}`);
-      await dispatch(detailModule.getGame(gameId));
+      await dispatch(detailModule.getGame(gameId!));
       break;
     case 'gameroster':
       const rosterModule = await import('../../components/lineup-view-game-roster');
       // Fetch the data for the given game id.
       console.log(`loading game roster page for ${gameId}`);
-      await dispatch(rosterModule.getGame(gameId));
+      await dispatch(rosterModule.getGame(gameId!));
       break;
     case 'viewRoster':
       import('../../components/lineup-view-roster');

--- a/src/slices/app/app-slice.ts
+++ b/src/slices/app/app-slice.ts
@@ -6,44 +6,6 @@ import { addTeam } from '../team/team-slice.js';
 
 const env = getEnv();
 
-export const loadPage = (page: string, gameId?: string): ThunkResult => async (dispatch) => {
-  console.log(`loadPage: page = ${page}, gameId = ${gameId}`);
-  switch (page) {
-    case 'viewHome':
-      import('../../components/lineup-view-home').then(() => {
-        // Put code in here that you want to run every time when
-        // navigating to viewHome after lineup-view-home.js is loaded.
-      });
-      break;
-    case 'viewGames':
-      import('../../components/lineup-view-games');
-      break;
-    case 'game':
-      const detailModule = await import('../../components/lineup-view-game-detail');
-      // Fetch the data for the given game id.
-      console.log(`loading game detail page for ${gameId}`);
-      await dispatch(detailModule.getGame(gameId!));
-      break;
-    case 'gameroster':
-      const rosterModule = await import('../../components/lineup-view-game-roster');
-      // Fetch the data for the given game id.
-      console.log(`loading game roster page for ${gameId}`);
-      await dispatch(rosterModule.getGame(gameId!));
-      break;
-    case 'viewRoster':
-      import('../../components/lineup-view-roster');
-      break;
-    case 'addNewTeam':
-      import('../../components/lineup-view-team-create');
-      break;
-    default:
-      page = 'view404';
-      import('../../components/lineup-view404');
-  }
-
-  dispatch(updatePage(page));
-};
-
 let snackbarTimer: number;
 
 export const showSnackbar = (): ThunkResult => (dispatch) => {

--- a/src/slices/game/game-slice.ts
+++ b/src/slices/game/game-slice.ts
@@ -199,8 +199,7 @@ const gameSlice = createSlice({
       }
 
       state.game = gameDetail;
-      // TODO: Ensure games state has latest game detail
-      // newState.games[action.game.id] = action.game;
+      state.games[action.payload.id] = gameDetail;
     });
     builder.addCase(getGame.rejected, (state: GameState,
       action: ReturnType<typeof copyRoster.rejected>) => {
@@ -237,3 +236,14 @@ export const { addGame, gamePlayerAdded } = actions;
 
 export const selectCurrentGameId = (state: RootState) => state.game?.gameId;
 export const selectCurrentGame = (state: RootState) => state.game?.game;
+
+export const selectGameById = (state: RootState, gameId: string) => {
+  if (!gameId) {
+    return;
+  }
+  return state.game?.games[gameId] as GameDetail;
+}
+
+export const selectGameRosterLoading = (state: RootState) => {
+  return state.game?.rosterLoading;
+}

--- a/src/slices/game/roster-logic.ts
+++ b/src/slices/game/roster-logic.ts
@@ -84,7 +84,7 @@ export const rosterCopyPendingHandler = (state: GameState,
 export const rosterCopiedHandler = (state: GameState, action: PayloadAction<RosterCopiedPayload>) => {
   // Set new roster, if required.
   if (action.payload.gameRoster && (Object.keys(state.game!.roster).length === 0)) {
-    const gameRoster = action.payload.gameRoster!;
+    const gameRoster = action.payload.gameRoster;
     const roster: Roster = {};
     Object.keys(gameRoster).forEach((key) => {
       const teamPlayer: Player = gameRoster[key];

--- a/src/slices/game/roster-logic.ts
+++ b/src/slices/game/roster-logic.ts
@@ -92,8 +92,9 @@ export const rosterCopiedHandler = (state: GameState, action: PayloadAction<Rost
       roster[player.id] = player;
     });
     state.game!.roster = roster;
-    // TODO: Ensure games state has latest game detail
-    // newState.games[action.game.id] = gameWithRoster;
+    const game = state.games[action.payload.gameId] as GameDetail;
+    game.hasDetail = true;
+    game.roster = roster;
   }
 
   state.rosterFailure = false;

--- a/test/integration/functional-game.ts
+++ b/test/integration/functional-game.ts
@@ -50,9 +50,6 @@ describe('Game functional tests', function () {
     await gameRosterPage.init();
     await gameRosterPage.open({ signIn: true });
 
-    // TODO: Implement waiting for view to be loaded/rendered
-    await gameRosterPage.page.waitForTimeout(500);
-
     // Verify that the game roster is initially empty.
     const emptyPlayers = await gameRosterPage.getPlayers();
     expect(emptyPlayers, 'Game should not have any players').to.be.empty;

--- a/test/integration/pages/game-detail-page.ts
+++ b/test/integration/pages/game-detail-page.ts
@@ -1,4 +1,4 @@
-import { PageObject, PageOptions } from './page-object.js';
+import { PageObject, PageOpenFunction, PageOptions } from './page-object.js';
 
 export class GameDetailPage extends PageObject {
 
@@ -8,6 +8,12 @@ export class GameDetailPage extends PageObject {
       scenarioName: 'viewGameDetail',
       route: `game/${options.gameId}`
     });
+  }
+
+  protected override get openFunc(): PageOpenFunction | undefined {
+    return async () => {
+      await this.page.waitForTimeout(2000);
+    }
   }
 
 }

--- a/test/integration/pages/game-roster-page.ts
+++ b/test/integration/pages/game-roster-page.ts
@@ -7,7 +7,8 @@ export class GameRosterPage extends PageObject {
     super({
       ...options,
       scenarioName: 'game roster',
-      route: `gameroster/${options.gameId}`
+      route: `gameroster/${options.gameId}`,
+      componentName: 'lineup-view-game-roster',
     });
   }
 

--- a/test/integration/pages/game-roster-page.ts
+++ b/test/integration/pages/game-roster-page.ts
@@ -40,7 +40,6 @@ export class GameRosterPage extends PageObject {
       throw new Error('Copy roster button not found');
     }
     await buttonHandle.click();
-    // TODO: Check for spinner/loading, instead of just waiting for arbitrary amount of time.
-    await this.page.waitForTimeout(3000);
+    await this.waitForViewReady();
   }
 }

--- a/test/unit/components/lineup-game-setup.test.ts
+++ b/test/unit/components/lineup-game-setup.test.ts
@@ -308,10 +308,16 @@ describe('lineup-game-setup tests', () => {
     for (const stepTest of stepTests) {
       const stepName = SetupSteps[stepTest.step];
       describe(stepName, () => {
+        let pushStateSpy: sinon.SinonSpy;
+        let gameId: string;
 
         beforeEach(async () => {
+          pushStateSpy = sinon.spy(window.history, 'pushState');
+
           const newGame = getGameDetail();
           expect(newGame.status).to.equal(GameStatus.New);
+
+          gameId = newGame.id;
 
           const gameState = buildGameStateWithCurrentGame(newGame);
 
@@ -320,6 +326,10 @@ describe('lineup-game-setup tests', () => {
 
           await setupElement(buildRootState(gameState, liveState));
           await el.updateComplete;
+        });
+
+        afterEach(() => {
+          pushStateSpy?.restore();
         });
 
         it('perform handler fires only when active', async () => {
@@ -346,8 +356,7 @@ describe('lineup-game-setup tests', () => {
           } else if (stepTest.step === SetupSteps.Roster) {
             // Verifies that it navigated to the roster page.
             await el.updateComplete;
-            // TODO: Verify param to dispatch call when it's a simple action instead of a thunk.
-            expect(dispatchStub).to.have.callCount(1);
+            expect(pushStateSpy).to.be.calledOnceWith({}, '', `/gameroster/${gameId}`);
           } else {
             // Other steps should do nothing (they don't have an href on the link).
             expect(dispatchStub).to.not.have.been.called;

--- a/test/unit/components/lineup-game-setup.test.ts
+++ b/test/unit/components/lineup-game-setup.test.ts
@@ -4,6 +4,7 @@ import '@app/components/lineup-game-setup.js';
 import { LineupOnPlayerList } from '@app/components/lineup-on-player-list';
 import { LineupPlayerCard } from '@app/components/lineup-player-card';
 import { LineupPlayerList } from '@app/components/lineup-player-list';
+import { PageRouter } from '@app/components/page-router.js';
 import { addMiddleware, removeMiddleware } from '@app/middleware/dynamic-middlewares';
 import { FormationBuilder, FormationType, getPositions } from '@app/models/formation';
 import { GameDetail, GameStatus, SetupStatus, SetupSteps, SetupTask } from '@app/models/game.js';
@@ -18,6 +19,7 @@ import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import sinon from 'sinon';
 import { buildGameStateWithCurrentGame } from '../helpers/game-state-setup.js';
 import { buildLiveStateWithCurrentGame } from '../helpers/live-state-setup.js';
+import { mockPageRouter } from '../helpers/mock-page-router.js';
 import { buildRootState } from '../helpers/root-state-setup.js';
 import { buildRoster, getNewGameDetail, getStoredPlayer, STORED_GAME_ID } from '../helpers/test_data';
 
@@ -115,12 +117,21 @@ describe('lineup-game-setup tests', () => {
     removeMiddleware(actionLoggerMiddleware);
   });
 
-  async function setupElement(preloadedState?: RootState) {
+  async function setupElement(preloadedState?: RootState): Promise<PageRouter> {
     const store = setupStore(preloadedState);
 
+    const mockRouter = {
+      gotoPage: () => {
+        // No-op, meant to be spied.
+        return Promise.resolve();
+      }
+    }
+    const parentNode = document.createElement('div');
+    mockPageRouter(parentNode, mockRouter);
     const template = html`<lineup-game-setup .store=${store} .storeConfigurator=${getLiveStoreConfigurator(false)}></lineup-game-setup>`;
-    el = await fixture(template);
+    el = await fixture(template, { parentNode });
     dispatchStub = sinon.spy(el, 'dispatch');
+    return mockRouter;
   }
 
   function getStore() {
@@ -308,12 +319,10 @@ describe('lineup-game-setup tests', () => {
     for (const stepTest of stepTests) {
       const stepName = SetupSteps[stepTest.step];
       describe(stepName, () => {
-        let pushStateSpy: sinon.SinonSpy;
+        let pageRouterSpy: sinon.SinonSpy;
         let gameId: string;
 
         beforeEach(async () => {
-          pushStateSpy = sinon.spy(window.history, 'pushState');
-
           const newGame = getGameDetail();
           expect(newGame.status).to.equal(GameStatus.New);
 
@@ -324,12 +333,13 @@ describe('lineup-game-setup tests', () => {
           // Sets up the current step as active.
           const liveState = buildLiveStateWithTasks(newGame, stepTest.step - 1);
 
-          await setupElement(buildRootState(gameState, liveState));
+          const mockRouter = await setupElement(buildRootState(gameState, liveState));
+          pageRouterSpy = sinon.spy(mockRouter, 'gotoPage');
           await el.updateComplete;
         });
 
         afterEach(() => {
-          pushStateSpy?.restore();
+          pageRouterSpy?.restore();
         });
 
         it('perform handler fires only when active', async () => {
@@ -356,7 +366,7 @@ describe('lineup-game-setup tests', () => {
           } else if (stepTest.step === SetupSteps.Roster) {
             // Verifies that it navigated to the roster page.
             await el.updateComplete;
-            expect(pushStateSpy).to.be.calledOnceWith({}, '', `/gameroster/${gameId}`);
+            expect(pageRouterSpy).to.be.calledOnceWith(`/gameroster/${gameId}`);
           } else {
             // Other steps should do nothing (they don't have an href on the link).
             expect(dispatchStub).to.not.have.been.called;

--- a/test/unit/components/lineup-view-game-detail.test.ts
+++ b/test/unit/components/lineup-view-game-detail.test.ts
@@ -1,15 +1,16 @@
-import { LineupViewGameDetail } from '@app/components/lineup-view-game-detail';
+import { LineupViewGameDetail } from '@app/components/lineup-view-game-detail.js';
 import '@app/components/lineup-view-game-detail.js';
-import { GameDetail, GameStatus } from '@app/models/game';
+import { GameDetail, GameStatus } from '@app/models/game.js';
 import { LiveGame } from '@app/models/live.js';
-import { getGameStoreConfigurator } from '@app/slices/game-store';
-import { RootState, setupStore } from '@app/store';
+import { getGameStoreConfigurator } from '@app/slices/game-store.js';
+import { RootState, setupStore } from '@app/store.js';
 import { expect, fixture, html } from '@open-wc/testing';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { buildGameStateWithCurrentGame } from '../helpers/game-state-setup.js';
 import { buildLiveStateWithCurrentGame } from '../helpers/live-state-setup.js';
 import { buildRootState } from '../helpers/root-state-setup.js';
 import * as testlive from '../helpers/test-live-game-data.js';
-import { buildRoster, getNewGameDetail } from '../helpers/test_data';
+import { buildRoster, getNewGameDetail } from '../helpers/test_data.js';
 
 function getGameDetail(): { game: GameDetail, live: LiveGame } {
   const live = testlive.getLiveGameWithPlayers();
@@ -20,10 +21,10 @@ function getGameDetail(): { game: GameDetail, live: LiveGame } {
 describe('lineup-view-game-detail tests', () => {
   let el: LineupViewGameDetail;
 
-  async function setupElement(preloadedState?: RootState) {
+  async function setupElement(preloadedState?: RootState, gameId?: string) {
     const store = setupStore(preloadedState);
 
-    const template = html`<lineup-view-game-detail active .store=${store} .storeConfigurator=${getGameStoreConfigurator(false)}></lineup-view-game-detail>`;
+    const template = html`<lineup-view-game-detail gameId="${ifDefined(gameId)}" active .store=${store} .storeConfigurator=${getGameStoreConfigurator(false)}></lineup-view-game-detail>`;
     el = await fixture(template);
   }
 
@@ -51,7 +52,7 @@ describe('lineup-view-game-detail tests', () => {
     const gameState = buildGameStateWithCurrentGame(game);
     const liveState = buildLiveStateWithCurrentGame(live);
 
-    await setupElement(buildRootState(gameState, liveState));
+    await setupElement(buildRootState(gameState, liveState), game.id);
     await el.updateComplete;
 
     const gameSetupElement = el.shadowRoot!.querySelector('section lineup-game-setup');
@@ -67,7 +68,7 @@ describe('lineup-view-game-detail tests', () => {
     const gameState = buildGameStateWithCurrentGame(game);
     const liveState = buildLiveStateWithCurrentGame(live);
 
-    await setupElement(buildRootState(gameState, liveState));
+    await setupElement(buildRootState(gameState, liveState), game.id);
 
     const liveElement = el.shadowRoot!.querySelector('section lineup-game-live');
     expect(liveElement, 'Live element should be shown').to.be.ok;

--- a/test/unit/helpers/game-state-setup.ts
+++ b/test/unit/helpers/game-state-setup.ts
@@ -1,20 +1,9 @@
 import { GameDetail } from '@app/models/game.js';
-import { GameState } from '@app/slices/game/game-slice.js';
-
-const INITIAL_STATE: GameState = {
-  gameId: '',
-  game: undefined,
-  games: {},
-  detailLoading: false,
-  detailFailure: false,
-  rosterLoading: false,
-  rosterFailure: false,
-  error: ''
-};
+import { GameState, GAME_INITIAL_STATE } from '@app/slices/game/game-slice.js';
 
 export function buildInitialGameState(): GameState {
   return {
-    ...INITIAL_STATE,
+    ...GAME_INITIAL_STATE,
     // Set to a new object, otherwise multiple tests will share the instance
     // on the constant.
     games: {}

--- a/test/unit/helpers/mock-page-router.ts
+++ b/test/unit/helpers/mock-page-router.ts
@@ -1,0 +1,10 @@
+import { pageRouterContext, PageRouter } from "@app/components/page-router.js";
+
+export function mockPageRouter(parentNode: HTMLElement, router: PageRouter) {
+  parentNode.addEventListener('context-request', event => {
+    if (event.context == pageRouterContext) {
+      event.stopPropagation();
+      event.callback(router);
+    }
+  });
+}


### PR DESCRIPTION
- Use lit-router to handle changes to the location, and trigger loading of view component
- Remove the navigate() action
- Actual loading and rendering of components is unchanged for now