### PR TITLE
Wait for user to be signed in before loading data

### DIFF
--- a/src/components/lineup-view-game-detail.ts
+++ b/src/components/lineup-view-game-detail.ts
@@ -4,6 +4,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { updateMetadata } from 'pwa-helpers/metadata.js';
 import { connectStore } from '../middleware/connect-mixin';
 import { GameDetail, GameStatus } from '../models/game.js';
+import { selectCurrentUserId } from '../slices/auth/auth-slice.js';
 import { getGameStore } from '../slices/game-store.js';
 import { getGame, selectGameById } from '../slices/game/game-slice.js';
 import { RootState, RootStore, SliceStoreConfigurator } from '../store';
@@ -64,16 +65,21 @@ export class LineupViewGameDetail extends connectStore()(PageViewElement) {
   @state()
   private game?: GameDetail;
 
+  @state()
+  private userSignedIn = false;
+
   private gameLoaded = false;
 
   override stateChanged(state: RootState) {
-    if (!this.gameId) {
+    this.userSignedIn = !!selectCurrentUserId(state);
+    if (!this.gameId || !this.userSignedIn) {
       return;
     }
     this.game = selectGameById(state, this.gameId);
     this.gameLoaded = !!this.game?.hasDetail;
   }
 
+  protected override authPropertyName = 'userSignedIn';
   protected override keyPropertyName = 'gameId';
 
   protected override loadData() {

--- a/src/components/lineup-view-game-roster.ts
+++ b/src/components/lineup-view-game-roster.ts
@@ -6,6 +6,7 @@ import { updateMetadata } from 'pwa-helpers/metadata.js';
 import { connectStore } from '../middleware/connect-mixin';
 import { GameDetail, GameStatus } from '../models/game.js';
 import { Roster } from '../models/player.js';
+import { selectCurrentUserId } from '../slices/auth/auth-slice.js';
 import { getGameStore } from '../slices/game-store.js';
 import { addNewGamePlayer, copyRoster, getGame, selectGameById, selectGameRosterLoading } from '../slices/game/game-slice.js';
 import { RootState, RootStore, SliceStoreConfigurator } from '../store.js';
@@ -90,10 +91,14 @@ export class LineupViewGameRoster extends connectStore()(PageViewElement) {
   @state()
   private _copyingInProgress = false;
 
+  @state()
+  private userSignedIn = false;
+
   private gameLoaded = false;
 
   override stateChanged(state: RootState) {
-    if (!this.gameId) {
+    this.userSignedIn = !!selectCurrentUserId(state);
+    if (!this.gameId || !this.userSignedIn) {
       return;
     }
     this.game = selectGameById(state, this.gameId);
@@ -102,10 +107,11 @@ export class LineupViewGameRoster extends connectStore()(PageViewElement) {
     this._copyingInProgress = !!selectGameRosterLoading(state);
   }
 
+  protected override authPropertyName = 'userSignedIn';
   protected override keyPropertyName = 'gameId';
 
   protected override loadData() {
-    if (this.gameId) {
+    if (this.userSignedIn && this.gameId) {
       this.dispatch(getGame(this.gameId));
     }
   }

--- a/src/components/page-view-element.ts
+++ b/src/components/page-view-element.ts
@@ -14,6 +14,8 @@ export declare class PageViewInterface {
   protected resetData(): void;
 
   // These members are to be overridden.
+  // Name of the property that determines if the user is allowed to view the page.
+  protected authPropertyName: string;
   // Name of the property that determines which data is loaded.
   protected keyPropertyName: string;
   // Load data in response to a change in the key property.
@@ -31,6 +33,7 @@ export const PageViewMixin = <T extends Constructor<LitElement>, K extends keyof
     @property({ type: Boolean, reflect: true })
     public ready = false;
 
+    protected authPropertyName?: K;
     protected keyPropertyName?: K;
 
     // Only render this page if it's actually visible.
@@ -41,11 +44,17 @@ export const PageViewMixin = <T extends Constructor<LitElement>, K extends keyof
     override willUpdate(changedProperties: PropertyValues) {
       super.willUpdate(changedProperties);
 
-      if (this.keyPropertyName && changedProperties.has(this.keyPropertyName)) {
+      if ((this.keyPropertyName && changedProperties.has(this.keyPropertyName)) ||
+        (this.authPropertyName && changedProperties.has(this.authPropertyName))) {
         // TODO: Find a less hacky way to do this.
         const keyValue = ((this as any)[this.keyPropertyName]) as string;// this.getKeyProperty();
+        let authValue = true;
+        if (this.authPropertyName) {
+          // TODO: Find a less hacky way to do this.
+          authValue = !!(((this as any)[this.authPropertyName]) as boolean);
+        }
         this.resetData();
-        if (keyValue) {
+        if (keyValue && authValue) {
           this.loadData();
         }
         return;

--- a/test/unit/components/__snapshots__/lineup-view-game-detail.test.snap.js
+++ b/test/unit/components/__snapshots__/lineup-view-game-detail.test.snap.js
@@ -31,3 +31,12 @@ snapshots["lineup-view-game-detail tests shows live component for started game"]
 </section>
 `;
 /* end snapshot lineup-view-game-detail tests shows live component for started game */
+snapshots["lineup-view-game-detail tests shows no game placeholder when not signed in"] = 
+`<section>
+  <p class="empty-list">
+    Game not found.
+  </p>
+</section>
+`;
+/* end snapshot lineup-view-game-detail tests shows no game placeholder when not signed in */
+

--- a/test/unit/components/__snapshots__/lineup-view-game-roster.test.snap.js
+++ b/test/unit/components/__snapshots__/lineup-view-game-roster.test.snap.js
@@ -41,3 +41,12 @@ snapshots["lineup-view-game-roster tests shows player list when game roster is n
 `;
 /* end snapshot lineup-view-game-roster tests shows player list when game roster is not empty */
 
+snapshots["lineup-view-game-roster tests shows no game placeholder when not signed in"] = 
+`<section>
+  <p class="empty-list">
+    Game not found.
+  </p>
+</section>
+`;
+/* end snapshot lineup-view-game-roster tests shows no game placeholder when not signed in */
+


### PR DESCRIPTION
- Main goal is to reduce errors/flakiness in integration tests.
- Change the data loading to explicitly check and block on the user being signed in.
- The PageViewElement allows pages to opt into auth being required.
- For now, the affected pages renders the "no game" placeholder when not signed in.
- Future refactoring to reduce boilerplate in pages.