### PR TITLE
Allow zero extra minutes for overdue period

### DIFF
--- a/src/slices/live/live-action-creators.ts
+++ b/src/slices/live/live-action-creators.ts
@@ -38,7 +38,7 @@ export const endPeriodCreator =
     }
     let retroactiveStopTime;
     if (
-      extraMinutes &&
+      (extraMinutes || extraMinutes === 0) &&
       game.clock?.periodStatus === PeriodStatus.Overdue &&
       game.clock.timer?.isRunning
     ) {

--- a/test/unit/slices/live/clock-reducer-logic.test.ts
+++ b/test/unit/slices/live/clock-reducer-logic.test.ts
@@ -465,6 +465,27 @@ describe('Live slice: Clock actions', () => {
         );
       });
 
+      it('should dispatch action for overdue period with explicit zero extra minutes when clock running', async () => {
+        mockTimeProvider(timeStartPlus20Minutes);
+        const currentGame = getGame(currentState, gameId)!;
+        currentGame.clock = buildClock(buildRunningTimer(startTime), {
+          currentPeriod: 1,
+          periodStatus: PeriodStatus.Overdue,
+          periodLength: 15,
+        });
+
+        const dispatchMock = sinon.stub();
+        const getStateMock = mockGetState(undefined, undefined, undefined, currentState);
+
+        endPeriodCreator(gameId, /*extraMinutes=*/ 0)(dispatchMock, getStateMock, undefined);
+
+        expect(dispatchMock).to.have.callCount(1);
+
+        expect(dispatchMock.lastCall).to.have.been.calledWith(
+          endPeriod(gameId, timeStartPlus15Minutes)
+        );
+      });
+
       it('should dispatch action for overdue period without extra minutes when clock stopped', async () => {
         mockTimeProvider(timeStartPlus20Minutes);
         const currentGame = getGame(currentState, gameId)!;


### PR DESCRIPTION
- If zero extra minutes was specified to end an overdue period, the value was ignored, and the current time used to end the period.